### PR TITLE
refactor: propagate errors

### DIFF
--- a/hydrabooster/run-node.go
+++ b/hydrabooster/run-node.go
@@ -117,7 +117,7 @@ func RunMany(dbpath string, getPort func() int, many, bucketSize, bsCon int, rel
 			limiter:    limiter,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to spawn node with swarm address %v: %w", laddr, err)
+			return fmt.Errorf("failed to spawn node with swarm address %v: %w", addr, err)
 		}
 		node.Network().Notify(notifiee)
 		nodes = append(nodes, node)
@@ -177,7 +177,7 @@ func printStatusLine(ndht int, start time.Time, totalpeers int64, uniqpeers uint
 }
 
 // RunSingleDHTWithUI ...
-func RunSingleDHTWithUI(path string, relay bool, bucketSize int) {
+func RunSingleDHTWithUI(path string, relay bool, bucketSize int) error {
 	datastore, err := levelds.NewDatastore(path, nil)
 
 	if err != nil {

--- a/hydrabooster/run-node.go
+++ b/hydrabooster/run-node.go
@@ -75,7 +75,6 @@ func waitForNotifications(r io.Reader, provs chan *provInfo, mesout chan string)
 // RunMany ...
 func RunMany(dbpath string, getPort func() int, many, bucketSize, bsCon int, relay bool, stagger time.Duration) error {
 	sharedDatastore, err := levelds.NewDatastore(dbpath, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to create datastore: %w", err)
 	}
@@ -179,7 +178,6 @@ func printStatusLine(ndht int, start time.Time, totalpeers int64, uniqpeers uint
 // RunSingleDHTWithUI ...
 func RunSingleDHTWithUI(path string, relay bool, bucketSize int) error {
 	datastore, err := levelds.NewDatastore(path, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to create datastore: %w", err)
 	}

--- a/hydrabooster/run-node.go
+++ b/hydrabooster/run-node.go
@@ -49,6 +49,8 @@ type provInfo struct {
 	Duration time.Duration
 }
 
+const singleDHTSwarmAddr = "/ip4/0.0.0.0/tcp/19264"
+
 func waitForNotifications(r io.Reader, provs chan *provInfo, mesout chan string) {
 	var e map[string]interface{}
 	dec := json.NewDecoder(r)
@@ -71,10 +73,11 @@ func waitForNotifications(r io.Reader, provs chan *provInfo, mesout chan string)
 }
 
 // RunMany ...
-func RunMany(dbpath string, getPort func() int, many, bucketSize, bsCon int, relay bool, stagger time.Duration) {
+func RunMany(dbpath string, getPort func() int, many, bucketSize, bsCon int, relay bool, stagger time.Duration) error {
 	sharedDatastore, err := levelds.NewDatastore(dbpath, nil)
+
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create datastore: %w", err)
 	}
 
 	start := time.Now()
@@ -114,7 +117,7 @@ func RunMany(dbpath string, getPort func() int, many, bucketSize, bsCon int, rel
 			limiter:    limiter,
 		})
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to spawn node with swarm address %v: %w", laddr, err)
 		}
 		node.Network().Notify(notifiee)
 		nodes = append(nodes, node)
@@ -176,18 +179,21 @@ func printStatusLine(ndht int, start time.Time, totalpeers int64, uniqpeers uint
 // RunSingleDHTWithUI ...
 func RunSingleDHTWithUI(path string, relay bool, bucketSize int) {
 	datastore, err := levelds.NewDatastore(path, nil)
+
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create datastore: %w", err)
 	}
+
 	node, _, err := SpawnNode(&SpawnNodeOpts{
 		datastore:  datastore,
-		addr:       "/ip4/0.0.0.0/tcp/19264",
+		addr:       singleDHTSwarmAddr,
 		relay:      relay,
 		bucketSize: bucketSize,
 		limiter:    nil,
 	})
+
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to spawn node with swarm address %v: %w", singleDHTSwarmAddr, err)
 	}
 
 	uniqpeers := make(map[peer.ID]struct{})

--- a/hydrabooster/spawn-node.go
+++ b/hydrabooster/spawn-node.go
@@ -82,7 +82,7 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 				continue
 			}
 			if err := node.Connect(context.Background(), *addr); err != nil {
-				fmt.Printf("bootstrap connect failed with err %w. Trying again\n", err)
+				fmt.Printf("bootstrap connect failed with error %v. Trying again\n", err)
 				continue
 			}
 			break

--- a/hydrabooster/spawn-node.go
+++ b/hydrabooster/spawn-node.go
@@ -82,7 +82,7 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 				continue
 			}
 			if err := node.Connect(context.Background(), *addr); err != nil {
-				fmt.Println("bootstrap connect failed: ", err)
+				fmt.Printf("bootstrap connect failed with err %w. Trying again\n", err)
 				continue
 			}
 			break

--- a/hydrabooster/spawn-node.go
+++ b/hydrabooster/spawn-node.go
@@ -41,7 +41,6 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 	cmgr := connmgr.NewConnManager(1500, 2000, time.Minute)
 
 	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
-
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
 	}
@@ -53,7 +52,6 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 	}
 
 	node, err := libp2p.New(context.Background(), libp2pOpts...)
-
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to spawn libp2p node: %w", err)
 	}
@@ -62,7 +60,6 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 		"pk":   record.PublicKeyValidator{},
 		"ipns": ipns.Validator{KeyBook: node.Peerstore()},
 	}))
-
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to instantiate DHT: %w", err)
 	}
@@ -80,17 +77,14 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 
 		for {
 			addr, err := randBootstrapAddr()
-
 			if err != nil {
 				fmt.Println("failed to get random bootstrap multiaddr", err)
 				continue
 			}
-
 			if err := node.Connect(context.Background(), *addr); err != nil {
 				fmt.Println("bootstrap connect failed: ", err)
 				continue
 			}
-
 			break
 		}
 

--- a/hydrabooster/spawn-node.go
+++ b/hydrabooster/spawn-node.go
@@ -14,20 +14,15 @@ import (
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	record "github.com/libp2p/go-libp2p-record"
 )
 
-func bootstrapperAddrs() pstore.PeerInfo {
+func randBootstrapAddr() (*peer.AddrInfo, error) {
 	addr := dht.DefaultBootstrapPeers[rand.Intn(len(dht.DefaultBootstrapPeers))]
-	ai, err := pstore.InfoFromP2pAddr(addr)
-	if err != nil {
-		panic(err)
-	}
-
-	return *ai
+	return peer.AddrInfoFromP2pAddr(addr)
 }
 
 var bootstrapDone int64
@@ -45,7 +40,11 @@ type SpawnNodeOpts struct {
 func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 	cmgr := connmgr.NewConnManager(1500, 2000, time.Minute)
 
-	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
 
 	libp2pOpts := []libp2p.Option{libp2p.ListenAddrStrings(opts.addr), libp2p.ConnectionManager(cmgr), libp2p.Identity(priv)}
 
@@ -54,16 +53,18 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 	}
 
 	node, err := libp2p.New(context.Background(), libp2pOpts...)
+
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("failed to spawn libp2p node: %w", err)
 	}
 
 	dhtNode, err := dht.New(context.Background(), node, dhtopts.BucketSize(opts.bucketSize), dhtopts.Datastore(opts.datastore), dhtopts.Validator(record.NamespacedValidator{
 		"pk":   record.PublicKeyValidator{},
 		"ipns": ipns.Validator{KeyBook: node.Peerstore()},
 	}))
+
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("failed to instantiate DHT: %w", err)
 	}
 
 	// bootstrap in the background
@@ -77,18 +78,27 @@ func SpawnNode(opts *SpawnNodeOpts) (host.Host, *dht.IpfsDHT, error) {
 			opts.limiter <- struct{}{}
 		}
 
-		// ❓ tries to connect to bootstrappers 2x, why?
-		for i := 0; i < 2; i++ {
-			if err := node.Connect(context.Background(), bootstrapperAddrs()); err != nil {
-				fmt.Println("bootstrap connect failed: ", err)
-				i--
+		for {
+			addr, err := randBootstrapAddr()
+
+			if err != nil {
+				fmt.Println("failed to get random bootstrap multiaddr", err)
+				continue
 			}
+
+			if err := node.Connect(context.Background(), *addr); err != nil {
+				fmt.Println("bootstrap connect failed: ", err)
+				continue
+			}
+
+			break
 		}
 
 		if opts.limiter != nil {
 			<-opts.limiter
 		}
-		atomic.AddInt64(&bootstrapDone, 1)
+
+		atomic.AddInt64(&bootstrapDone, 1) // TODO return a channel to signal when bootstrap is done or error occurred
 
 	}()
 	return node, dhtNode, nil

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"time"
 
 	id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
@@ -41,7 +42,7 @@ func main() {
 	if *many == -1 {
 		err := hydrabooster.RunSingleDHTWithUI(*dbpath, *relay, *bucketSize)
 		if err != nil {
-			panic(err)
+			log.Fatalln(err)
 		}
 
 		return
@@ -50,6 +51,6 @@ func main() {
 	getPort := hydrabooster.PortSelector(*portBegin)
 	err := hydrabooster.RunMany(*dbpath, getPort, *many, *bucketSize, *bootstrapConcurency, *relay, *stagger)
 	if err != nil {
-		panic(err)
+		log.Fatalln(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -39,10 +39,20 @@ func main() {
 	}
 
 	if *many == -1 {
-		hydrabooster.RunSingleDHTWithUI(*dbpath, *relay, *bucketSize)
+		err := hydrabooster.RunSingleDHTWithUI(*dbpath, *relay, *bucketSize)
+
+		if err != nil {
+			panic(err)
+		}
+
 		return
 	}
 
 	getPort := hydrabooster.PortSelector(*portBegin)
 	hydrabooster.RunMany(*dbpath, getPort, *many, *bucketSize, *bootstrapConcurency, *relay, *stagger)
+	err := hydrabooster.RunMany(*dbpath, getPort, *many, *bucketSize, *bootstrapConcurency, *relay, *stagger)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -40,7 +40,6 @@ func main() {
 
 	if *many == -1 {
 		err := hydrabooster.RunSingleDHTWithUI(*dbpath, *relay, *bucketSize)
-
 		if err != nil {
 			panic(err)
 		}
@@ -49,9 +48,7 @@ func main() {
 	}
 
 	getPort := hydrabooster.PortSelector(*portBegin)
-	hydrabooster.RunMany(*dbpath, getPort, *many, *bucketSize, *bootstrapConcurency, *relay, *stagger)
 	err := hydrabooster.RunMany(*dbpath, getPort, *many, *bucketSize, *bootstrapConcurency, *relay, *stagger)
-
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Returns wrapped errors* (to provide context) up to main. At the top level we `panic(err)`...or perhaps we should `log.Fatalln(err)` instead?

\* with `%w` - see https://golang.org/pkg/fmt/#Errorf