### PR TITLE
test: add spawn node test

### DIFF
--- a/hydrabooster/spawn-node_test.go
+++ b/hydrabooster/spawn-node_test.go
@@ -1,0 +1,39 @@
+package hydrabooster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+)
+
+func TestSpawnNode(t *testing.T) {
+	node, _, bsCh, err := SpawnNode(SpawnNodeOptions{
+		datastore:  datastore.NewMapDatastore(),
+		addr:       "/ip4/0.0.0.0/tcp/0",
+		bucketSize: 20,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		status, ok := <-bsCh
+		if !ok {
+			t.Fatal(fmt.Errorf("channel closed before bootstrap complete"))
+		}
+		if status.err != nil {
+			t.Fatal(status.err)
+		}
+		if status.done {
+			break
+		}
+	}
+
+	err = node.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds a basic test to ensure spawning a node works successfully.

ALSO! Does a little refactoring to `spawnNode` to make it return a channel on which we can receive status updates for progress on connecting to a bootstrap node.

It allows us to test this function better by being told when the boostrap process is complete instead of checking a global internal int64 variable `bootstrapDone` periodically.

Previously `spawnNode` it just incremented `bootstrapDone,` but now each call to `spawnNode` will know exactly when it is bootstrapped and which node became bootstrapped.

The `bootstrapDone` global internal variable has moved to `run-node.go` which may/may not be refactored away at a later date.

COVERAGE FTW! https://codecov.io/gh/libp2p/hydra-booster/commits