### PR TITLE
feat: expose datastore and routing table on hydra node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/libp2p/go-libp2p-circuit v0.1.4
 	github.com/libp2p/go-libp2p-connmgr v0.2.1
 	github.com/libp2p/go-libp2p-core v0.3.1-0.20191230184106-204a57d1afe1
+	github.com/libp2p/go-libp2p-kbucket v0.2.3
 	github.com/libp2p/go-libp2p-kad-dht v0.4.2-0.20191230184437-fd2e9b7e3db2
 	github.com/libp2p/go-libp2p-record v0.1.2
 	github.com/multiformats/go-multiaddr v0.2.0

--- a/node/opts/options.go
+++ b/node/opts/options.go
@@ -6,12 +6,14 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
+	kbucket "github.com/libp2p/go-libp2p-kbucket"
 	"github.com/multiformats/go-multiaddr"
 )
 
 // Options are Hydra Node options
 type Options struct {
 	Datastore      ds.Batching
+	RoutingTable   *kbucket.RoutingTable
 	Relay          bool
 	Addr           multiaddr.Multiaddr
 	BucketSize     int
@@ -48,6 +50,15 @@ var Defaults = func(o *Options) error {
 func Datastore(ds ds.Batching) Option {
 	return func(o *Options) error {
 		o.Datastore = ds
+		return nil
+	}
+}
+
+// RoutingTable configures the Hydra Node to use the specified routing table.
+// Defaults to the routing table provided by IpfsDHT.
+func RoutingTable(rt *kbucket.RoutingTable) Option {
+	return func(o *Options) error {
+		o.RoutingTable = rt
 		return nil
 	}
 }


### PR DESCRIPTION
Also adds a `RoutingTable` option (which is currently ignored)