### PR TITLE
feat: allow num sybils to be set via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,10 @@ COPY . .
 
 RUN go build -o hydra-booster .
 
+# HTTP API
+EXPOSE 7779
+# Prometheus /metrics
+EXPOSE 8888
+# Sybils
 EXPOSE 10000-12000
-CMD ["./hydra-booster", "-many=50", "-portBegin=10000"]
+CMD ["./hydra-booster", "-portBegin=10000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 7779
 EXPOSE 8888
 # Sybils
 EXPOSE 10000-12000
-CMD ["./hydra-booster", "-portBegin=10000"]
+CMD ["./hydra-booster", "-portBegin=10000", "-metrics-port=8888"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 > A DHT Indexer node & Peer Router
 
-A new type of DHT node designed to accelerate the Content Resolution & Content Providing on the IPFS Network. A (cute) Hydra with one belly full of records and many heads (PeerIds) to tell other nodes about them, charged with rocket boosters to transport other nodes to their destination faster.
+A new type of DHT node designed to accelerate the Content Resolution & Content Providing on the IPFS Network. A (cute) Hydra with one belly full of records and many heads (Peer IDs) to tell other nodes about them, charged with rocket boosters to transport other nodes to their destination faster.
 
 [**Read the RFC**](https://docs.google.com/document/d/1yA2fY5c0WIv3LCtJCPVesHzvCWt14OPv7QlHdV3ghgU).
 Disclaimer: We are at Stage 1 of the RFC. [**Kanban**](https://app.zenhub.com/workspaces/hydra-booster-5e64ef0d1fa19e698b659cec/board?repos=245123455)
@@ -38,24 +38,25 @@ go get -u github.com/libp2p/hydra-booster
 
 ## Usage
 
-`hydra-booster` has two modes. A 'single dht' mode that has a nicer UI, this is intended to be run in a tmux window or something so you can see statistics about your contribution to the network.
+`hydra-booster` has two modes. A 'single head' mode that has a nicer UI, this is intended to be run in a tmux window or something so you can see statistics about your contribution to the network.
 
 ```sh
 go run ./main.go
 ```
 
-The second mode is called 'many mode'. Passing the `-many=N` allows you to run N dhts at a time in the same process. It periodically prints out a status line with information about total peers, uptime, and memory usage.
-
+The second mode is called 'many mode'. Passing the `-nsybils=N` allows you to run N heads (called [sybils](https://en.wikipedia.org/wiki/Sybil_attack)) at a time in the same process. It periodically prints out a status line with information about total peers, uptime, and memory usage.
 
 ```sh
-go run ./main.go -many=5
+go run ./main.go -nsybils=5
 ```
+
+ALternatively you can use the `HYDRA_NSYBILS` environment var to specify the number of sybils. Note the `-nsybils` flag takes precedence.
 
 ### Best Practices
 
-Only run a hydra-booster on machines with public IP addresses. Having more dht nodes behind NATs makes dht queries in general slower, as connecting in generally takes longer and sometimes doesnt even work (resulting in a timeout).
+Only run a `hydra-booster` on machines with public IP addresses. Having more DHT nodes behind NATs makes DHT queries in general slower, as connecting in generally takes longer and sometimes doesnt even work (resulting in a timeout).
 
-When running with `-many`, please make sure to bump the ulimit to something fairly high. Expect ~500 connections per node youre running (so with `-many=10`, try setting `ulimit -n 5000`)
+When running with `-nsybils`, please make sure to bump the ulimit to something fairly high. Expect ~500 connections per node youre running (so with `-nsybils=10`, try setting `ulimit -n 5000`)
 
 ## Developers
 
@@ -86,7 +87,7 @@ prometheus --config.file=promconfig.yaml --storage.tsdb.path=prometheus-data
 Next start the Hydra Booster, specifying the port to run metrics on:
 
 ```console
-go run ./main.go -many=5 -metrics-port=8888
+go run ./main.go -nsybils=5 -metrics-port=8888
 ```
 
 You should now be able to access metrics at http://127.0.0.1:9090.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ go get -u github.com/libp2p/hydra-booster
 go run ./main.go
 ```
 
-The second mode is called 'many mode'. Passing the `-nsybils=N` allows you to run N heads (called [sybils](https://en.wikipedia.org/wiki/Sybil_attack)) at a time in the same process. It periodically prints out a status line with information about total peers, uptime, and memory usage.
+The second mode is called 'many heads'. Passing the `-nsybils=N` allows you to run N heads (called [sybils](https://en.wikipedia.org/wiki/Sybil_attack)) at a time in the same process. It periodically prints out a status line with information about total peers, uptime, and memory usage.
 
 ```sh
 go run ./main.go -nsybils=5
 ```
 
-ALternatively you can use the `HYDRA_NSYBILS` environment var to specify the number of sybils. Note the `-nsybils` flag takes precedence.
+Alternatively you can use the `HYDRA_NSYBILS` environment var to specify the number of sybils. Note the `-nsybils` flag takes precedence.
 
 ### Best Practices
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 
 func main() {
 	start := time.Now()
-	many := flag.Int("many", -1, "Instead of running one dht, run many!")
+	nsybils := flag.Int("nsybils", -1, "Specify the number of Hydra sybils to create.")
 	dbpath := flag.String("db", "hydra-belly", "Datastore folder path")
 	inmem := flag.Bool("mem", false, "Use an in-memory database. This overrides the -db option")
 	metricsPort := flag.Int("metrics-port", 8888, "Specify a port to run prometheus metrics and pprof http server on")
@@ -50,15 +50,15 @@ func main() {
 		*dbpath = ""
 	}
 
-	if *many == -1 {
-		if os.Getenv("HYDRA_MANY") != "" {
-			envMany, err := strconv.Atoi(os.Getenv("HYDRA_MANY"))
+	if *nsybils == -1 {
+		if os.Getenv("HYDRA_NSYBILS") != "" {
+			envNSybils, err := strconv.Atoi(os.Getenv("HYDRA_NSYBILS"))
 			if err != nil {
-				log.Fatalln(fmt.Errorf("invalid HYDRA_MANY env value: %w", err))
+				log.Fatalln(fmt.Errorf("invalid HYDRA_NSYBILS env value: %w", err))
 			}
-			*many = envMany
+			*nsybils = envNSybils
 		} else {
-			*many = 1
+			*nsybils = 1
 		}
 	}
 
@@ -74,7 +74,7 @@ func main() {
 		Relay:         *relay,
 		BucketSize:    *bucketSize,
 		GetPort:       utils.PortSelector(*portBegin),
-		NSybils:       *many,
+		NSybils:       *nsybils,
 		BsCon:         *bootstrapConcurency,
 		Stagger:       *stagger,
 	}


### PR DESCRIPTION
Allows us to dynamically increase/decrease the number of sybils a hydra spawns via the `HYDRA_MANY` env var. This means that we do not need to commit, tag and publish a new docker image version when we want to tweak the value :)

Also exposes the HTTP API and `/metrics` ports.