### PR TITLE
fix: specify httpapi address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 7779
 EXPOSE 8888
 # Sybils
 EXPOSE 10000-12000
-CMD ["./hydra-booster", "-portBegin=10000", "-metrics-port=8888"]
+CMD ["./hydra-booster", "-port-begin=10000", "-metrics-addr=0.0.0.0:8888", "-httpapi-addr=0.0.0.0:7779"]

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,7 +16,7 @@ import (
 var PrometheusNamespace = "hydrabooster"
 
 // ListenAndServe sets up an endpoint to collect process metrics (e.g. pprof).
-func ListenAndServe(port int) error {
+func ListenAndServe(address string) error {
 	// setup Prometheus
 	registry := prom.NewRegistry()
 	goCollector := prom.NewGoCollector()
@@ -46,5 +46,5 @@ func ListenAndServe(port int) error {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-	return http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), mux)
+	return http.ListenAndServe(address, mux)
 }


### PR DESCRIPTION
resolves #45

Also:

* changes `-metrics-port` to `-metrics-addr` for consistency and flexibility.
* changes `-portBegin`, `-bucketSize` and `-bootstrapConc` to kebab case `-port-begin`, `-bucket-size` and `-bootstrap-conc` for consistency.
* removes the ability to _not_ expose metrics server (since UI depends on them). Do not want it public? Specify `127.0.0.1:8888` as the `-metrics-addr`.