### PR TITLE
chore: avoid time.After

### DIFF
--- a/hydra/periodicmetrics.go
+++ b/hydra/periodicmetrics.go
@@ -24,15 +24,18 @@ func NewPeriodicMetrics(ctx context.Context, hy *Hydra, period time.Duration) *P
 	}
 
 	go func() {
+		timer := time.NewTimer(period)
+		defer timer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(period):
+			case <-timer.C:
 				err := pm.periodicCollectAndRecord(ctx)
 				if err != nil {
 					fmt.Println(fmt.Errorf("failed to collect and record stats: %w", err))
 				}
+				timer.Reset(period)
 			}
 		}
 	}()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -41,21 +41,19 @@ func (ui *UI) Render(ctx context.Context) error {
 	mC := make(chan []*pmc.Metric)
 
 	go func() {
-		ms, err := client.GetMetrics()
-		if err != nil {
-			fmt.Println(err)
-		}
-		mC <- ms
+		timer := time.NewTimer(0)
+		defer timer.Stop()
 
 		for {
 			select {
-			case <-time.After(ui.options.RefreshPeriod):
+			case <-timer.C:
 				ms, err := client.GetMetrics()
 				if err != nil {
 					fmt.Println(err)
 				} else {
 					mC <- ms
 				}
+				timer.Reset(ui.options.RefreshPeriod)
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
It allocates a timer every time and can't be canceled. It's better and often simpler to just use a timer.