### PR TITLE
fix: don't leak the ticker

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -95,6 +95,7 @@ func (ui *UI) Render(ctx context.Context) error {
 		ga.Print()
 
 		seconds := time.NewTicker(time.Second)
+		defer seconds.Stop()
 
 		for {
 			select {


### PR DESCRIPTION
We only call Render once, so this shouldn't be a huge issue.