### PR TITLE
feat: user agent with correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ When running with `-nheads`, please make sure to bump the ulimit to something fa
 
 ## Developers
 
+### Release a new version
+
+1. Update version number in [`version.go`](version/version.go).
+2. Create a semver tag with "v" prefix e.g. `git tag v0.1.7`.
+3. See [`deployment.md#continuous-deployment`](docs/deployment.md#continuous-deployment) for what happens next.
+
 ### Publish a new image
 
 ```console

--- a/head/head.go
+++ b/head/head.go
@@ -20,6 +20,7 @@ import (
 	kbucket "github.com/libp2p/go-libp2p-kbucket"
 	record "github.com/libp2p/go-libp2p-record"
 	"github.com/libp2p/hydra-booster/head/opts"
+	"github.com/libp2p/hydra-booster/version"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -61,7 +62,17 @@ func NewHead(ctx context.Context, options ...opts.Option) (*Head, chan Bootstrap
 		return nil, nil, fmt.Errorf("failed to generate balanced private key: %w", err)
 	}
 
-	libp2pOpts := []libp2p.Option{libp2p.ListenAddrs(cfg.Addr), libp2p.ConnectionManager(cmgr), libp2p.Identity(priv)}
+	ua := version.UserAgent
+	if cfg.Relay {
+		ua += "+relay"
+	}
+
+	libp2pOpts := []libp2p.Option{
+		libp2p.UserAgent(version.UserAgent),
+		libp2p.ListenAddrs(cfg.Addr),
+		libp2p.ConnectionManager(cmgr),
+		libp2p.Identity(priv),
+	}
 
 	if cfg.Relay {
 		libp2pOpts = append(libp2pOpts, libp2p.EnableRelay(circuit.OptHop))

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
-	id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	"github.com/libp2p/hydra-booster/httpapi"
 	"github.com/libp2p/hydra-booster/hydra"
 	"github.com/libp2p/hydra-booster/idgen"
@@ -45,12 +44,6 @@ func main() {
 	name := flag.String("name", "", "A name for the Hydra (for use in metrics)")
 	idgenAddr := flag.String("idgen-addr", "", "Address of an idgen HTTP API endpoint to use for generating private keys for heads")
 	flag.Parse()
-	// Set the protocol for Identify to report on handshake
-	id.ClientVersion = "hydra-booster/1"
-
-	if *relay {
-		id.ClientVersion += "+relay"
-	}
 
 	if *inmem {
 		*dbpath = ""

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+const (
+	Version   = "0.1.7"
+	UserAgent = "hydra-booster/" + Version
+)


### PR DESCRIPTION
Adds a `version.go` file which we'll attempt to keep updated when releasing so that when collecting stats we can see the version that is being run.

![Screenshot 2020-04-14 at 15 20 28](https://user-images.githubusercontent.com/152863/79235600-ba427100-7e63-11ea-926d-dfbc746061c7.png)

Also, directly setting `identify.ClientVersion` is deprecated.