### PR TITLE
feat: add PostgreSQL datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Only run a `hydra-booster` on machines with public IP addresses. Having more DHT
 
 When running with `-nheads`, please make sure to bump the ulimit to something fairly high. Expect ~500 connections per node youre running (so with `-nheads=10`, try setting `ulimit -n 5000`)
 
+### Running Multiple Hydras
+
+The total number of heads a single Hydra can have depends on the resources of the machine it's running on. To get the desired number of heads you may need to run multiple Hydras on multiple machines. There's a couple of challenges with this:
+
+* Peer IDs of Hydra heads are balanced in the DHT. When running multiple Hydras it's necessary to designate one of the Hydras to be the "idgen server" and the rest to be "idgen clients" so that all Peer IDs in the Hydra swarm are balanced. Use the `-idgen-addr` flag or `HYDRA_IDGEN_ADDR` environment variable to ensure all Peer IDs in the Hydra swarm are balanced perfectly.
+* A datastore is shared by all Hydra heads but not by all Hydras. Use the `-db` flag or `HYDRA_DB` environment variable to specify a PostgreSQL database connection string that can be shared by all Hydras in the swarm.
+
 ## Developers
 
 ### Publish a new image

--- a/datastore/postgres.go
+++ b/datastore/postgres.go
@@ -1,0 +1,24 @@
+package datastore
+
+import (
+	"database/sql"
+	"fmt"
+
+	sqlds "github.com/alanshaw/sql-datastore"
+	"github.com/alanshaw/sql-datastore/postgres"
+)
+
+// NewPostgreSQLDatastore creates a new sqlds.Datastore that talks to a PostgreSQL database
+func NewPostgreSQLDatastore(connstr string) (*sqlds.Datastore, error) {
+	db, err := sql.Open("postgres", connstr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open PostgreSQL database: %w", err)
+	}
+
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS blocks (key TEXT NOT NULL UNIQUE, data BYTEA NOT NULL)")
+	if err != nil {
+		return nil, fmt.Errorf("failed to init PostgreSQL database: %w", err)
+	}
+
+	return sqlds.NewDatastore(db, postgres.Queries{}), nil
+}

--- a/datastore/postgres.go
+++ b/datastore/postgres.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	sqlds "github.com/alanshaw/sql-datastore"
-	"github.com/alanshaw/sql-datastore/postgres"
+	sqlds "github.com/ipfs/go-ds-sql"
+	"github.com/ipfs/go-ds-sql/postgres"
 )
 
 // NewPostgreSQLDatastore creates a new sqlds.Datastore that talks to a PostgreSQL database

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/alanshaw/ipfs-hookds v0.2.0
 	github.com/alanshaw/prom-metrics-client v0.3.0
+	github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/snappy v0.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/alanshaw/ipfs-hookds v0.2.0
 	github.com/alanshaw/prom-metrics-client v0.3.0
-	github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/snappy v0.0.1 // indirect
@@ -13,6 +12,7 @@ require (
 	github.com/ipfs/go-cid v0.0.5
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-ds-leveldb v0.4.2
+	github.com/ipfs/go-ds-sql v0.1.0
 	github.com/ipfs/go-ipns v0.0.2
 	github.com/libp2p/go-libp2p v0.7.2
 	github.com/libp2p/go-libp2p-circuit v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/alanshaw/prom-metrics-client v0.2.0 h1:bQVECOMIuHabVA3/aLY9Ahh2hLYFby
 github.com/alanshaw/prom-metrics-client v0.2.0/go.mod h1:PAIsdFNQd5vGDP+AEa+KmYqGfZTXd951YE4AP2xP7gM=
 github.com/alanshaw/prom-metrics-client v0.3.0 h1:HfkAEmViUMyL4L6dSA2uR3+d+2Fw+yZUAPpRXV5ju0I=
 github.com/alanshaw/prom-metrics-client v0.3.0/go.mod h1:PAIsdFNQd5vGDP+AEa+KmYqGfZTXd951YE4AP2xP7gM=
+github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d h1:Qap62ekAMQ/Hy9dJl8Ju0DO2WDtBFp6OIwekbhpv9OA=
+github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d/go.mod h1:yAySTQsHXyRjkfYQpyu7LBHuLcNbpuE5tW+S/twmqc8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -219,6 +221,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/libp2p/go-addr-util v0.0.1 h1:TpTQm9cXVRVSKsYbgQ7GKc3KbbHVTnbostgGaDEP+88=
 github.com/libp2p/go-addr-util v0.0.1/go.mod h1:4ac6O7n9rIAKB1dnd+s8IbbMXkt+oBpzX4/+RACcnlQ=
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/alanshaw/prom-metrics-client v0.2.0 h1:bQVECOMIuHabVA3/aLY9Ahh2hLYFby
 github.com/alanshaw/prom-metrics-client v0.2.0/go.mod h1:PAIsdFNQd5vGDP+AEa+KmYqGfZTXd951YE4AP2xP7gM=
 github.com/alanshaw/prom-metrics-client v0.3.0 h1:HfkAEmViUMyL4L6dSA2uR3+d+2Fw+yZUAPpRXV5ju0I=
 github.com/alanshaw/prom-metrics-client v0.3.0/go.mod h1:PAIsdFNQd5vGDP+AEa+KmYqGfZTXd951YE4AP2xP7gM=
-github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d h1:Qap62ekAMQ/Hy9dJl8Ju0DO2WDtBFp6OIwekbhpv9OA=
-github.com/alanshaw/sql-datastore v0.0.0-20200415144513-d2fc2f9add3d/go.mod h1:yAySTQsHXyRjkfYQpyu7LBHuLcNbpuE5tW+S/twmqc8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -170,6 +168,8 @@ github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZ
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-ds-leveldb v0.4.2 h1:QmQoAJ9WkPMUfBLnu1sBVy0xWWlJPg0m4kRAiJL9iaw=
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
+github.com/ipfs/go-ds-sql v0.1.0 h1:5PzIXPmhyVDj1YPXzxJc0r2mobFs3g1JumdWKdp0x5Q=
+github.com/ipfs/go-ds-sql v0.1.0/go.mod h1:/c47NpRiHobwn+8F8EpW0yBy8d3Mx/j/tIlrVN1e1Ec=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 func main() {
 	start := time.Now()
 	nheads := flag.Int("nheads", -1, "Specify the number of Hydra heads to create.")
-	dbpath := flag.String("db", "hydra-belly", "Datastore folder path")
+	dbpath := flag.String("db", "hydra-belly", "Datastore directory (for LevelDB store) or postgresql:// connection string (for PostgreSQL store)")
 	httpAPIAddr := flag.String("httpapi-addr", defaultHTTPAPIAddr, "Specify an IP and port to run prometheus metrics and pprof http server on")
 	inmem := flag.Bool("mem", false, "Use an in-memory database. This overrides the -db option")
 	metricsAddr := flag.String("metrics-addr", defaultMetricsAddr, "Specify an IP and port to run prometheus metrics and pprof http server on")
@@ -54,6 +54,8 @@ func main() {
 
 	if *inmem {
 		*dbpath = ""
+	} else if *dbpath == "" {
+		*dbpath = os.Getenv("HYDRA_DB")
 	}
 
 	if *nheads == -1 {


### PR DESCRIPTION
This PR adds a [sql-datastore](https://github.com/whyrusleeping/sql-datastore) and enables connecting to a PostgreSQL database for the datastore.

This enables a datastore that'll persist across restarts and that can be shared by multiple Hydras.

The PostgreSQL datastore can be enabled by passing a postgres connection string with the `-db` flag or by using the `HYDRA_DB` env variable.

We need the following PRs to land so we can switch from my fork (in this order):

* [x] https://github.com/ipfs/go-ds-sql/pull/10
* [x] https://github.com/ipfs/go-ds-sql/pull/11
* [x] https://github.com/ipfs/go-ds-sql/pull/9

resolves https://github.com/libp2p/hydra-booster/issues/20