### PR TITLE
fix: disable k8s NAT

### DIFF
--- a/k8s/alasybil.yaml
+++ b/k8s/alasybil.yaml
@@ -54,6 +54,9 @@ spec:
     app: alasybil
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32601

--- a/k8s/bubbles.yaml
+++ b/k8s/bubbles.yaml
@@ -60,6 +60,9 @@ spec:
     app: bubbles
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32611

--- a/k8s/chumpy.yaml
+++ b/k8s/chumpy.yaml
@@ -60,6 +60,9 @@ spec:
     app: chumpy
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32621

--- a/k8s/domino.yaml
+++ b/k8s/domino.yaml
@@ -60,6 +60,9 @@ spec:
     app: domino
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32631

--- a/k8s/euclid.yaml
+++ b/k8s/euclid.yaml
@@ -60,6 +60,9 @@ spec:
     app: euclid
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32641

--- a/k8s/flake.yaml
+++ b/k8s/flake.yaml
@@ -58,6 +58,9 @@ spec:
     app: flake
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32651

--- a/k8s/grendel.yaml
+++ b/k8s/grendel.yaml
@@ -58,6 +58,9 @@ spec:
     app: grendel
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32661

--- a/k8s/hojo.yaml
+++ b/k8s/hojo.yaml
@@ -58,6 +58,9 @@ spec:
     app: hojo
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32671

--- a/k8s/ibycus.yaml
+++ b/k8s/ibycus.yaml
@@ -58,6 +58,9 @@ spec:
     app: ibycus
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32681

--- a/k8s/jetta.yaml
+++ b/k8s/jetta.yaml
@@ -58,6 +58,9 @@ spec:
     app: jetta
   sessionAffinity: None
   type: NodePort
+  # Do not NAT inbound connections or Hydra heads receive incorrect addresses for Peers
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+  externalTrafficPolicy: Local
   ports:
   - name: metrics
     nodePort: 32691


### PR DESCRIPTION
Do not NAT inbound connections or Hydra heads receive incorrect remote addresses for Peers.