### PR TITLE
fix: increase read timeout

### DIFF
--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -26,7 +26,7 @@ func ListenAndServe(hy *hydra.Hydra, addr string) error {
 	srv := &http.Server{
 		Addr: addr,
 		// Good practice to set timeouts to avoid Slowloris attacks.
-		WriteTimeout: time.Second * 15,
+		WriteTimeout: time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		IdleTimeout:  time.Second * 60,
 		Handler:      NewRouter(hy),

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -27,7 +27,7 @@ func ListenAndServe(hy *hydra.Hydra, addr string) error {
 		Addr: addr,
 		// Good practice to set timeouts to avoid Slowloris attacks.
 		WriteTimeout: time.Second * 15,
-		ReadTimeout:  time.Second * 15,
+		ReadTimeout:  time.Second * 60,
 		IdleTimeout:  time.Second * 60,
 		Handler:      NewRouter(hy),
 	}


### PR DESCRIPTION
15s is not a lot of time to read or write the entire response especially when we have 100k of peer addresses to respond with.