### PR TITLE
chore: update libp2p-kad-dht dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ Usage of hydra-booster:
         Disable storing and retrieving value records, note that for some protocols, like "/ipfs", it MUST be false (default false).
   -enable-relay
         Enable libp2p circuit relaying for this node (default false).
-  -enable-v1-compat
-        Enables DHT v1 compatibility (default true).
   -httpapi-addr string
         Specify an IP and port to run the HTTP API server on (default "127.0.0.1:7779")
   -idgen-addr string
@@ -126,8 +124,6 @@ Usage of hydra-booster:
         Disable counting provider records for metrics reporting (default false).
   HYDRA_DISABLE_PROV_GC
         Disable provider record garbage collection (default false).
-  HYDRA_ENABLE_V1_COMPAT
-        Enables DHT v1 compatibility (default true).
   HYDRA_IDGEN_ADDR string
         Address of an idgen HTTP API endpoint to use for generating private keys for heads
   HYDRA_NAME string

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/libp2p/go-libp2p-circuit v0.3.1
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.6.1
-	github.com/libp2p/go-libp2p-kad-dht v0.9.0
+	github.com/libp2p/go-libp2p-kad-dht v0.10.0
 	github.com/libp2p/go-libp2p-kbucket v0.4.7
 	github.com/libp2p/go-libp2p-noise v0.1.1
 	github.com/libp2p/go-libp2p-peerstore v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,6 @@ github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfx
 github.com/libp2p/go-libp2p-discovery v0.3.0/go.mod h1:o03drFnz9BVAZdzC/QUQ+NeQOu38Fu7LJGEOK2gQltw=
 github.com/libp2p/go-libp2p-discovery v0.5.0 h1:Qfl+e5+lfDgwdrXdu4YNCWyEo3fWuP+WgN9mN0iWviQ=
 github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKBIcr4SfDcm0/PfPJLug=
-github.com/libp2p/go-libp2p-kad-dht v0.9.0 h1:AKeFYZvfAa/32Sgm0LrPDxGXB62AUtU8MRqqMobBfUM=
-github.com/libp2p/go-libp2p-kad-dht v0.9.0/go.mod h1:LEKcCFHxnvypOPaqZ0m6h0fLQ9Y8t1iZMOg7a0aQDD4=
 github.com/libp2p/go-libp2p-kad-dht v0.10.0 h1:Id7B3pBudm/F3hEEn/gQPOSsx7su9o6hoQ+NU02AQ4g=
 github.com/libp2p/go-libp2p-kad-dht v0.10.0/go.mod h1:LEKcCFHxnvypOPaqZ0m6h0fLQ9Y8t1iZMOg7a0aQDD4=
 github.com/libp2p/go-libp2p-kbucket v0.4.7 h1:spZAcgxifvFZHBD8tErvppbnNiKA5uokDu3CV7axu70=

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ github.com/libp2p/go-libp2p-discovery v0.5.0 h1:Qfl+e5+lfDgwdrXdu4YNCWyEo3fWuP+W
 github.com/libp2p/go-libp2p-discovery v0.5.0/go.mod h1:+srtPIU9gDaBNu//UHvcdliKBIcr4SfDcm0/PfPJLug=
 github.com/libp2p/go-libp2p-kad-dht v0.9.0 h1:AKeFYZvfAa/32Sgm0LrPDxGXB62AUtU8MRqqMobBfUM=
 github.com/libp2p/go-libp2p-kad-dht v0.9.0/go.mod h1:LEKcCFHxnvypOPaqZ0m6h0fLQ9Y8t1iZMOg7a0aQDD4=
+github.com/libp2p/go-libp2p-kad-dht v0.10.0 h1:Id7B3pBudm/F3hEEn/gQPOSsx7su9o6hoQ+NU02AQ4g=
+github.com/libp2p/go-libp2p-kad-dht v0.10.0/go.mod h1:LEKcCFHxnvypOPaqZ0m6h0fLQ9Y8t1iZMOg7a0aQDD4=
 github.com/libp2p/go-libp2p-kbucket v0.4.7 h1:spZAcgxifvFZHBD8tErvppbnNiKA5uokDu3CV7axu70=
 github.com/libp2p/go-libp2p-kbucket v0.4.7/go.mod h1:XyVo99AfQH0foSf176k4jY1xUJ2+jUJIZCSDm7r2YKk=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=

--- a/head/head.go
+++ b/head/head.go
@@ -110,7 +110,6 @@ func NewHead(ctx context.Context, options ...opts.Option) (*Head, chan Bootstrap
 		dht.Datastore(cfg.Datastore),
 		dht.QueryFilter(dht.PublicQueryFilter),
 		dht.RoutingTableFilter(dht.PublicRoutingTableFilter),
-		dht.V1CompatibleMode(cfg.EnableV1Compat),
 	}
 
 	if cfg.DisableProvGC {

--- a/head/head_test.go
+++ b/head/head_test.go
@@ -90,33 +90,6 @@ func TestSpawnHeadWithCustomProtocolPrefix(t *testing.T) { // TODO spawn a node 
 	}
 }
 
-func TestSpawnHeadWithV1Compat(t *testing.T) { // TODO spawn a node to bootstrap from so we don't hit the public bootstrappers
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	_, bsCh, err := NewHead(
-		ctx,
-		opts.Datastore(datastore.NewMapDatastore()),
-		opts.EnableV1Compat(),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for {
-		status, ok := <-bsCh
-		if !ok {
-			t.Fatal(fmt.Errorf("channel closed before bootstrap complete"))
-		}
-		if status.Err != nil {
-			fmt.Println(status.Err)
-		}
-		if status.Done {
-			break
-		}
-	}
-}
-
 func TestSpawnHeadWithCustomPeerstore(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -28,7 +28,6 @@ type Options struct {
 	DisableProvGC    bool
 	DisableProviders bool
 	DisableValues    bool
-	EnableV1Compat   bool
 }
 
 // Option is the Hydra Head option type.
@@ -179,15 +178,6 @@ func DisableProviders() Option {
 func DisableValues() Option {
 	return func(o *Options) error {
 		o.DisableValues = true
-		return nil
-	}
-}
-
-// EnableV1Compat enables DHT v1 compatibility.
-// The default value is false.
-func EnableV1Compat() Option {
-	return func(o *Options) error {
-		o.EnableV1Compat = true
 		return nil
 	}
 }

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -62,7 +62,6 @@ type Options struct {
 	DisableProvGC     bool
 	DisableProviders  bool
 	DisableValues     bool
-	EnableV1Compat    bool
 	BootstrapPeers    []multiaddr.Multiaddr
 	DisablePrefetch   bool
 	DisableProvCounts bool
@@ -153,9 +152,6 @@ func NewHydra(ctx context.Context, options Options) (*Hydra, error) {
 		}
 		if options.DisableValues {
 			hdOpts = append(hdOpts, opts.DisableValues())
-		}
-		if options.EnableV1Compat {
-			hdOpts = append(hdOpts, opts.EnableV1Compat())
 		}
 		if options.PeerstorePath != "" {
 			pstoreDs, err := leveldb.NewDatastore(fmt.Sprintf("%s/head-%d", options.PeerstorePath, i), nil)

--- a/hydra/hydra_test.go
+++ b/hydra/hydra_test.go
@@ -83,24 +83,6 @@ func TestSpawnHydraWithCustomProtocolPrefix(t *testing.T) {
 	}
 }
 
-func TestSpawnHydraWithV1Compat(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	hy, err := NewHydra(ctx, Options{
-		NHeads:         2,
-		GetPort:        utils.PortSelector(3000),
-		EnableV1Compat: true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(hy.Heads) != 2 {
-		t.Fatal("expected hydra to spawn 2 heads")
-	}
-}
-
 func TestSpawnHydraWithPeerstorePath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/k8s/alasybil.yaml
+++ b/k8s/alasybil.yaml
@@ -26,8 +26,6 @@ spec:
           value: "30000"
         - name: HYDRA_NAME
           value: Alasybil
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/bubbles.yaml
+++ b/k8s/bubbles.yaml
@@ -28,8 +28,6 @@ spec:
           value: Bubbles
         - name: HYDRA_IDGEN_ADDR
           value: http://10.245.168.5:7779
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/chumpy.yaml
+++ b/k8s/chumpy.yaml
@@ -28,8 +28,6 @@ spec:
           value: Chumpy
         - name: HYDRA_IDGEN_ADDR
           value: http://10.245.168.5:7779
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/domino.yaml
+++ b/k8s/domino.yaml
@@ -28,8 +28,6 @@ spec:
           value: Domino
         - name: HYDRA_IDGEN_ADDR
           value: http://10.245.168.5:7779
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/euclid.yaml
+++ b/k8s/euclid.yaml
@@ -28,8 +28,6 @@ spec:
           value: Euclid
         - name: HYDRA_IDGEN_ADDR
           value: http://10.245.168.5:7779
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/flake.yaml
+++ b/k8s/flake.yaml
@@ -26,8 +26,6 @@ spec:
           value: "31250"
         - name: HYDRA_NAME
           value: Flake
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/grendel.yaml
+++ b/k8s/grendel.yaml
@@ -26,8 +26,6 @@ spec:
           value: "31500"
         - name: HYDRA_NAME
           value: Grendel
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/hojo.yaml
+++ b/k8s/hojo.yaml
@@ -26,8 +26,6 @@ spec:
           value: "31750"
         - name: HYDRA_NAME
           value: Hojo
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/ibycus.yaml
+++ b/k8s/ibycus.yaml
@@ -26,8 +26,6 @@ spec:
           value: "32000"
         - name: HYDRA_NAME
           value: Ibycus
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/k8s/jetta.yaml
+++ b/k8s/jetta.yaml
@@ -26,8 +26,6 @@ spec:
           value: "32250"
         - name: HYDRA_NAME
           value: Jetta
-        - name: HYDRA_ENABLE_V1_COMPAT
-          value: "true"
         - name: HYDRA_BOOTSTRAP_PEERS
           value: "/dnsaddr/sjc-2.bootstrap.libp2p.io/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp,/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         - name: HYDRA_DISABLE_PREFETCH

--- a/main.go
+++ b/main.go
@@ -53,7 +53,6 @@ func main() {
 	disableProvGC := flag.Bool("disable-prov-gc", false, "Disable provider record garbage collection (default false).")
 	disableProviders := flag.Bool("disable-providers", false, "Disable storing and retrieving provider records, note that for some protocols, like \"/ipfs\", it MUST be false (default false).")
 	disableValues := flag.Bool("disable-values", false, "Disable storing and retrieving value records, note that for some protocols, like \"/ipfs\", it MUST be false (default false).")
-	enableV1Compat := flag.Bool("enable-v1-compat", true, "Enables DHT v1 compatibility (default true).")
 	disablePrefetch := flag.Bool("disable-prefetch", false, "Disables pre-fetching of discovered provider records (default false).")
 	disableProvCounts := flag.Bool("disable-prov-counts", false, "Disable counting provider records for metrics reporting (default false).")
 	flag.Parse()
@@ -82,9 +81,6 @@ func main() {
 	}
 	if *disableProvGC == false {
 		*disableProvGC = mustGetEnvBool("HYDRA_DISABLE_PROV_GC", false)
-	}
-	if *enableV1Compat == false {
-		*enableV1Compat = mustGetEnvBool("HYDRA_ENABLE_V1_COMPAT", false)
 	}
 	if *bootstrapPeers == "" {
 		*bootstrapPeers = os.Getenv("HYDRA_BOOTSTRAP_PEERS")
@@ -136,7 +132,6 @@ func main() {
 		DisableProvGC:     *disableProvGC,
 		DisableProviders:  *disableProviders,
 		DisableValues:     *disableValues,
-		EnableV1Compat:    *enableV1Compat,
 		BootstrapPeers:    mustConvertToMultiaddr(*bootstrapPeers),
 		DisablePrefetch:   *disablePrefetch,
 		DisableProvCounts: *disableProvCounts,


### PR DESCRIPTION
This PR updates the libp2p-kad-dht dependency, which removes the v1 compat option (v2 did not happen in the end).

resolves #110