### PR TITLE
Optimised Docker build

### DIFF
--- a/utils/port-selector_test.go
+++ b/utils/port-selector_test.go
@@ -9,7 +9,7 @@ func TestPortSelector(t *testing.T) {
 	getPort := PortSelector(begin)
 	for i := begin; i < begin*1000; i++ {
 		port := getPort()
-		if port != i+1 {
+		if port != i {
 			t.Fatalf("expected next port to be %v but got %v", i+1, port)
 		}
 	}


### PR DESCRIPTION
Using an Alpine build image and then creating a run-image with only bare necessities.

Perhaps I'm not measuring right but I think I've gotten down to 50 MB from 450 MB for the whole Debian shebang.