### PR TITLE
Fix staticcheck

### DIFF
--- a/datastore/proxy.go
+++ b/datastore/proxy.go
@@ -156,7 +156,7 @@ func newOnAfterQueryHook(ctx context.Context, getRouting GetRoutingFunc, opts Op
 			}
 
 			pendingLock.Lock()
-			isPending, _ := pending[k.String()]
+			isPending := pending[k.String()]
 			if !isPending {
 				// send to the find provs queue, if channel is full then discard...
 				select {

--- a/head/head.go
+++ b/head/head.go
@@ -3,7 +3,6 @@ package head
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -38,15 +37,6 @@ const (
 	provCacheSize          = 256
 	provCacheExpiry        = time.Hour
 )
-
-func randBootstrapAddr(bootstrapPeers []multiaddr.Multiaddr) (*peer.AddrInfo, error) {
-	addr := bootstrapPeers[rand.Intn(len(bootstrapPeers))]
-	ai, err := peer.AddrInfoFromP2pAddr(addr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert %s to AddrInfo: %w", addr, err)
-	}
-	return ai, nil
-}
 
 // BootstrapStatus describes the status of connecting to a bootstrap node.
 type BootstrapStatus struct {

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -129,14 +129,14 @@ func idgenAddHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		pk, err := idgen.HydraIdentityGenerator.AddBalanced()
 		if err != nil {
-			fmt.Println(fmt.Errorf("Failed to generate Peer ID: %w", err))
+			fmt.Println(fmt.Errorf("failed to generate Peer ID: %w", err))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		b, err := crypto.MarshalPrivateKey(pk)
 		if err != nil {
-			fmt.Println(fmt.Errorf("Failed to extract private key bytes: %w", err))
+			fmt.Println(fmt.Errorf("failed to extract private key bytes: %w", err))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -169,7 +169,7 @@ func idgenRemoveHandler() func(http.ResponseWriter, *http.Request) {
 
 		err = idgen.HydraIdentityGenerator.Remove(pk)
 		if err != nil {
-			fmt.Println(fmt.Errorf("Failed to remove private key: %w", err))
+			fmt.Println(fmt.Errorf("failed to remove private key: %w", err))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func main() {
 	}()
 	fmt.Fprintf(os.Stderr, "🧩 HTTP API listening on http://%s\n", *httpAPIAddr)
 
-	termChan := make(chan os.Signal)
+	termChan := make(chan os.Signal, 1)
 	signal.Notify(termChan, os.Interrupt, syscall.SIGTERM)
 	<-termChan // Blocks here until either SIGINT or SIGTERM is received.
 	fmt.Println("Received interrupt signal, shutting down...")

--- a/main.go
+++ b/main.go
@@ -79,16 +79,16 @@ func main() {
 	if *idgenAddr == "" {
 		*idgenAddr = os.Getenv("HYDRA_IDGEN_ADDR")
 	}
-	if *disableProvGC == false {
+	if !*disableProvGC {
 		*disableProvGC = mustGetEnvBool("HYDRA_DISABLE_PROV_GC", false)
 	}
 	if *bootstrapPeers == "" {
 		*bootstrapPeers = os.Getenv("HYDRA_BOOTSTRAP_PEERS")
 	}
-	if *disablePrefetch == false {
+	if !*disablePrefetch {
 		*disablePrefetch = mustGetEnvBool("HYDRA_DISABLE_PREFETCH", false)
 	}
-	if *disableProvCounts == false {
+	if !*disableProvCounts {
 		*disableProvCounts = mustGetEnvBool("HYDRA_DISABLE_PROV_COUNTS", false)
 	}
 	if *pstorePath == "" {

--- a/ui/gooey.go
+++ b/ui/gooey.go
@@ -45,10 +45,6 @@ const (
 	LightGray
 )
 
-func color(color int, s string) string {
-	return fmt.Sprintf("\x1b[%dm%s\x1b[0m", color, s)
-}
-
 const width = 25
 
 func padPrint(writer io.Writer, line int, label, value string) {

--- a/ui/gooey.go
+++ b/ui/gooey.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strings"
 
-	human "github.com/dustin/go-humanize"
 	net "github.com/libp2p/go-libp2p-core/network"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -53,15 +52,6 @@ func padPrint(writer io.Writer, line int, label, value string) {
 
 func putMessage(writer io.Writer, line int, mes string) {
 	fmt.Fprintf(writer, "\033[%d;0H%s%s", line, QClrLine, mes)
-}
-
-func printDataSharedLine(writer io.Writer, line int, bup int, totup int64, rateup float64) {
-	pad := "            "
-	a := fmt.Sprintf("%d            ", bup)[:12]
-	b := (human.Bytes(uint64(totup)) + pad)[:12]
-	c := (human.Bytes(uint64(rateup)) + "/s" + pad)[:12]
-
-	padPrint(writer, line, "", a+b+c)
 }
 
 // GooeyApp ..


### PR DESCRIPTION
This is the naive approach to fixing each staticcheck warning.

`color()`, `printDataSharedLine()` in gooey, and `randBootstrapAddr()` head seem reasonable, even if they aren't (yet) called anywhere. Should we selectively ignore this lint warning, or just comment them out?