### PR TITLE
feat: Added add endpoint to the HTTP API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,29 @@ Returns an ndjson list of peers created by the Hydra: their IDs and mulitaddrs. 
 
 Returns an ndjson list of provider records stored by the Hydra Booster node.
 
+#### `POST /records/add`
+
+Adds new providers records to the Hydra Booster node's database. Will return HTTP status code 202 if all records were accepted and added to the node.
+
+If there is an error in the request payload then the entire payload is rejected with a HTTP status code 400.
+
+The request body must be a JSON formatted list of records containing the `CID` and and `PeerID` fields. All other fields are ignored.
+
+Example input:
+
+```json
+[
+  {
+    "CID": "QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm",
+    "PeerID": "12D3KooWHacdCMnm4YKDJHn72HPTxc6LRGNzbrbyVEnuLFA3FXCZ"
+  },
+  {
+    "CID": "QmbQDovX7wRe9ek7u6QXe9zgCXkTzoUSsTFJEkrYV1HrVR",
+    "PeerID": "12D3KooWHacdCMnm4YKDJHn72HPTxc6LRGNzbrbyVEnuLFA3FXCZ"
+  }
+]
+```
+
 #### `GET /records/fetch/{cid}?nProviders=1`
 
 Fetches provider record(s) available on the network by CID. Use the `nProviders` query string parameter to signal the number of provider records to find. Returns an ndjson list of provider peers: their IDs and mulitaddrs. Will return HTTP status code 404 if no records were found.

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -24,17 +24,17 @@ import (
 )
 
 type providerRecord struct {
-	CID cid.Cid
+	CID    cid.Cid
 	PeerID peer.ID
 }
 
 type rawProviderRecord struct {
-	CID string
+	CID    string
 	PeerID string
 }
 
-type apiError struct {
-	Error string `json:Error`
+type ApiError struct {
+	Error string `json:"Error"`
 }
 
 // ListenAndServe instructs a Hydra HTTP API server to listen and serve on the passed address
@@ -148,7 +148,7 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 		// Verify the Content-Type matches
 		contentTypes := r.Header["Content-Type"]
 
-		if len(contentTypes) < 1 || !strings.HasPrefix(contentTypes[0], "application/json") {			
+		if len(contentTypes) < 1 || !strings.HasPrefix(contentTypes[0], "application/json") {
 			writeApiErrorResponse(
 				w, http.StatusUnsupportedMediaType, "Request must specify the Content-Type header as \"application/json\".",
 			)
@@ -156,8 +156,8 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 		}
 
 		// Decode the body as JSON
-		body, err := ioutil.ReadAll(r.Body) 
-		if err != nil { 
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
 			fmt.Printf("Error on adding provider records while reading the request payload: %s\n", err)
 			writeApiErrorResponse(w, http.StatusInternalServerError, "")
 			return
@@ -165,7 +165,7 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 
 		var rawRecords []rawProviderRecord
 		err = json.Unmarshal(body, &rawRecords)
-		
+
 		if err != nil {
 			writeApiErrorResponse(w, http.StatusBadRequest, "Invalid request payload.")
 			return
@@ -173,7 +173,7 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 
 		// Prepare the records to add - We don't add directly as we want to operation to fail if any of the record is invalid
 		records := make([]providerRecord, len(rawRecords))
-		for i, rawRecord := range(rawRecords) {
+		for i, rawRecord := range rawRecords {
 			cid, err := cid.Decode(rawRecord.CID)
 
 			if err != nil {
@@ -193,7 +193,7 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 
 		// Store the new records locally
 		ctx := r.Context()
-		for _, record := range(records) {
+		for _, record := range records {
 			hy.Heads[0].AddProvider(ctx, record.CID, record.PeerID)
 		}
 
@@ -295,7 +295,7 @@ func writeApiErrorResponse(w http.ResponseWriter, status int, message string) {
 	if message != "" {
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(status)
-		json.NewEncoder(w).Encode(apiError{Error: message})
+		json.NewEncoder(w).Encode(ApiError{Error: message})
 	} else {
 		w.WriteHeader(status)
 	}

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -182,7 +182,6 @@ func recordAddHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request) 
 			}
 
 			peerId, err := peer.Decode(rawRecord.PeerID)
-
 			if err != nil {
 				writeApiErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("Invalid PeerID provided on record[%d].", i))
 				return

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -264,7 +264,7 @@ func TestHTTPAPIRecordsAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	peerIdStr := "12D3KooWHacdCMnm4YKDJHn72HPTxc6LRGNzbrbyVEnuLFA3FXCZ"
+	peerIdStr := "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC"
 	peerId, err := peer.Decode(peerIdStr)
 	if err != nil {
 		t.Fatal(err)
@@ -301,7 +301,7 @@ func TestHTTPAPIRecordsAdd(t *testing.T) {
 
 	results = providerRouter.ProviderManager.GetProviders(ctx, cid.Bytes())
 	if len(results) == 0 {
-		t.Fatal("The node datastore is empty at the beginning of the test.")
+		t.Fatal("The node datastore is empty at the end of the test.")
 	}
 
 	if results[0] != peerId {

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -9,15 +9,18 @@ import (
 	"github.com/libp2p/hydra-booster/head/opts"
 )
 
-// Defaults are the SpawnNode defaults
-var defaults = []opts.Option{
-	opts.Datastore(datastore.NewMapDatastore()),
-	opts.BootstrapPeers(nil),
-}
-
 // SpawnHead creates a new Hydra head with an in memory datastore and 0 bootstrap peers by default.
 // It also waits for bootstrapping to complete.
 func SpawnHead(ctx context.Context, options ...opts.Option) (*head.Head, error) {
+	/*
+		Defaults are the SpawnNode defaults.
+		It is not defined as a global so that the datastore is not shared between tests.
+	*/
+	defaults := []opts.Option{
+		opts.Datastore(datastore.NewMapDatastore()),
+		opts.BootstrapPeers(nil),
+	}
+
 	hd, bsCh, err := head.NewHead(ctx, append(defaults, options...)...)
 	if err != nil {
 		return nil, err

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -41,9 +41,14 @@ func SpawnHead(ctx context.Context, options ...opts.Option) (*head.Head, error) 
 
 // SpawnHeads creates n new Hydra nodes with an in memory datastore and 0 bootstrap peers by default
 func SpawnHeads(ctx context.Context, n int, options ...opts.Option) ([]*head.Head, error) {
+	defaults := []opts.Option{
+		opts.Datastore(datastore.NewMapDatastore()),
+		opts.BootstrapPeers(nil),
+	}
+
 	var hds []*head.Head
 	for i := 0; i < n; i++ {
-		hd, err := SpawnHead(ctx, options...)
+		hd, err := SpawnHead(ctx, append(defaults, options...)...)
 		if err != nil {
 			for _, nd := range hds {
 				nd.Host.Close()


### PR DESCRIPTION
Hello!
This PR adds a new endpoint to the HTTP API, `/records/add`.
The endpoint accepts a JSON formatted list of provider records, like the following one:

```json
[
  {
    "CID": "QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm",
    "PeerID": "12D3KooWHacdCMnm4YKDJHn72HPTxc6LRGNzbrbyVEnuLFA3FXCZ"
  },
  {
    "CID": "QmbQDovX7wRe9ek7u6QXe9zgCXkTzoUSsTFJEkrYV1HrVR",
    "PeerID": "12D3KooWHacdCMnm4YKDJHn72HPTxc6LRGNzbrbyVEnuLFA3FXCZ"
  }
]
```

The endpoint will be useful to enable alternative strategies to bootstrap, sync or update nodes outside of the DHT.
Hope this helps!

