### PR TITLE
Use raw multihash instead of raw CID as key in Head.AddProvider()

### DIFF
--- a/head/head.go
+++ b/head/head.go
@@ -200,5 +200,5 @@ func (s *Head) RoutingTable() *kbucket.RoutingTable {
 // AddProvider adds the given provider to the datastore
 func (s *Head) AddProvider(ctx context.Context, c cid.Cid, id peer.ID) {
 	dht, _ := s.Routing.(*dht.IpfsDHT)
-	dht.ProviderManager.AddProvider(ctx, c.Bytes(), id)
+	dht.ProviderManager.AddProvider(ctx, c.Hash(), id)
 }


### PR DESCRIPTION
DHT clients expect messages to contain raw multihashes, not CIDs. This works for CIDv0 but not CIDv1, since a raw CIDv0 is a raw multihash but a raw CIDv1 is not.

I believe the impact of this is that hydras will not find providers for CIDv1's added via Head.AddProvider (I believe the provider prefetching uses this), since clients will be requesting a different key than what was used in the datastore.