### PR TITLE
Add a storetheindex delegated provider

### DIFF
--- a/head/head.go
+++ b/head/head.go
@@ -134,6 +134,15 @@ func NewHead(ctx context.Context, options ...opts.Option) (*Head, chan Bootstrap
 		}
 		providerStore = hproviders.CombineProviders(providerStore, hproviders.AddProviderNotSupported(delegateProvider))
 	}
+	if cfg.StoreTheIndexAddr != "" {
+		log.Infof("will delegate to %v with timeout %v", cfg.StoreTheIndexAddr, cfg.DelegateTimeout)
+		delegateProvider, err := hproviders.DelegateProvider(cfg.DelegateAddr, cfg.DelegateTimeout)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to instantiate delegation client (%w)", err)
+		}
+		providerStore = hproviders.CombineProviders(providerStore, hproviders.AddProviderNotSupported(delegateProvider))
+
+	}
 	dhtOpts = append(dhtOpts, dht.ProviderStore(providerStore))
 
 	dhtNode, err := dht.New(ctx, node, dhtOpts...)

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -16,21 +16,22 @@ import (
 
 // Options are Hydra Head options
 type Options struct {
-	Datastore        ds.Batching
-	Peerstore        peerstore.Peerstore
-	DelegateAddr     string
-	DelegateTimeout  time.Duration
-	RoutingTable     *kbucket.RoutingTable
-	EnableRelay      bool
-	Addrs            []multiaddr.Multiaddr
-	ProtocolPrefix   protocol.ID
-	BucketSize       int
-	Limiter          chan struct{}
-	BootstrapPeers   []multiaddr.Multiaddr
-	ID               crypto.PrivKey
-	DisableProvGC    bool
-	DisableProviders bool
-	DisableValues    bool
+	Datastore         ds.Batching
+	Peerstore         peerstore.Peerstore
+	DelegateAddr      string
+	StoreTheIndexAddr string
+	DelegateTimeout   time.Duration
+	RoutingTable      *kbucket.RoutingTable
+	EnableRelay       bool
+	Addrs             []multiaddr.Multiaddr
+	ProtocolPrefix    protocol.ID
+	BucketSize        int
+	Limiter           chan struct{}
+	BootstrapPeers    []multiaddr.Multiaddr
+	ID                crypto.PrivKey
+	DisableProvGC     bool
+	DisableProviders  bool
+	DisableValues     bool
 }
 
 // Option is the Hydra Head option type.
@@ -82,6 +83,15 @@ func Peerstore(ps peerstore.Peerstore) Option {
 func DelegateAddr(addr string) Option {
 	return func(o *Options) error {
 		o.DelegateAddr = addr
+		return nil
+	}
+}
+
+// StoreTheIndexAddr configures the Hydra Head to delegate routing also to this storetheindex addr.
+// Defaults to empty string which indicates no delegation.
+func StoreTheIndexAddr(addr string) Option {
+	return func(o *Options) error {
+		o.StoreTheIndexAddr = addr
 		return nil
 	}
 }

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -53,6 +53,7 @@ type Options struct {
 	PeerstorePath     string
 	DelegateAddr      string
 	DelegateTimeout   time.Duration
+	StoreTheIndexAddr string
 	GetPort           func() int
 	NHeads            int
 	ProtocolPrefix    protocol.ID
@@ -155,6 +156,7 @@ func NewHydra(ctx context.Context, options Options) (*Hydra, error) {
 			opts.BootstrapPeers(options.BootstrapPeers),
 			opts.DelegateAddr(options.DelegateAddr),
 			opts.DelegateTimeout(options.DelegateTimeout),
+			opts.StoreTheIndexAddr(options.StoreTheIndexAddr),
 		}
 		if options.EnableRelay {
 			hdOpts = append(hdOpts, opts.EnableRelay())

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 	httpAPIAddr := flag.String("httpapi-addr", defaultHTTPAPIAddr, "Specify an IP and port to run the HTTP API server on")
 	delegateAddr := flag.String("delegate-addr", "", "API endpoint for delegated routing")
 	delegateTimeout := flag.Int("delegate-timeout", 0, "Timeout for delegated routing in seconds")
+	stiAddr := flag.String("store-the-index-addr", "", "StoreTheIndex API endpoint for delegated routing")
 	inmem := flag.Bool("mem", false, "Use an in-memory database. This overrides the -db option")
 	metricsAddr := flag.String("metrics-addr", defaultMetricsAddr, "Specify an IP and port to run Prometheus metrics and pprof HTTP server on")
 	enableRelay := flag.Bool("enable-relay", false, "Enable libp2p circuit relaying for this node (default false).")
@@ -115,6 +116,9 @@ func main() {
 	if *delegateTimeout == 0 {
 		*delegateTimeout = mustGetEnvInt("HYDRA_DELEGATED_ROUTING_TIMEOUT", 0)
 	}
+	if *stiAddr == "" {
+		*stiAddr = os.Getenv("HYDRA_STORE_THE_INDEX_ADDR")
+	}
 
 	// Allow short keys. Otherwise, we'll refuse connections from the bootsrappers and break the network.
 	// TODO: Remove this when we shut those bootstrappers down.
@@ -157,6 +161,7 @@ func main() {
 		PeerstorePath:     *pstorePath,
 		DelegateAddr:      *delegateAddr,
 		DelegateTimeout:   time.Second * time.Duration(*delegateTimeout),
+		StoreTheIndexAddr: *stiAddr,
 		EnableRelay:       *enableRelay,
 		ProtocolPrefix:    protocol.ID(*protocolPrefix),
 		BucketSize:        *bucketSize,

--- a/metrics/definitions.go
+++ b/metrics/definitions.go
@@ -44,6 +44,9 @@ var (
 	// "failed" if an error was encountered and the request failed.
 	DelegatedFindProvs         = stats.Int64("delegated_find_provs_total", "Total delegated find provider attempts that were found locally, or not found locally and succeeded, failed or were discarded", stats.UnitDimensionless)
 	DelegatedFindProvsDuration = stats.Float64("delegated_find_provs_duration_nanoseconds", "The time it took delegated find provider attempts from the network to succeed or fail because of timeout or completion", stats.UnitSeconds)
+
+	STIFindProvs         = stats.Int64("sti_find_provs_total", "Total store the index find provider attempts that were found locally, or not found locally and succeeded, failed or were discarded", stats.UnitDimensionless)
+	STIFindProvsDuration = stats.Float64("sti_find_provs_duration_nanoseconds", "The time it took storetheindex finds from the network to succeed or fail because of timeout or completion", stats.UnitSeconds)
 )
 
 // Views
@@ -91,6 +94,16 @@ var (
 	FindProvsQueueSizeView = &view.View{
 		Measure:     FindProvsQueueSize,
 		TagKeys:     []tag.Key{KeyName},
+		Aggregation: view.Sum(),
+	}
+	STIFindProvsView = &view.View{
+		Measure:     STIFindProvs,
+		TagKeys:     []tag.Key{KeyName, KeyStatus},
+		Aggregation: view.Sum(),
+	}
+	STIFindProvsDurationView = &view.View{
+		Measure:     STIFindProvsDuration,
+		TagKeys:     []tag.Key{KeyName, KeyStatus},
 		Aggregation: view.Sum(),
 	}
 	// DHT views
@@ -158,6 +171,8 @@ var DefaultViews = []*view.View{
 	FindProvsView,
 	FindProvsDurationView,
 	FindProvsQueueSizeView,
+	STIFindProvsView,
+	STIFindProvsDurationView,
 	// DHT views
 	ReceivedMessagesView,
 	ReceivedMessageErrorsView,

--- a/providers/storetheindex.go
+++ b/providers/storetheindex.go
@@ -1,0 +1,52 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-kad-dht/providers"
+	"github.com/libp2p/hydra-booster/metrics"
+	"github.com/libp2p/hydra-booster/providers/storetheindex"
+	"github.com/multiformats/go-multihash"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+func StoreTheIndexProvider(endpointURL string, timeout time.Duration) (providers.ProviderStore, error) {
+	c, err := storetheindex.New(endpointURL, storetheindex.WithHTTPClient(&http.Client{Timeout: timeout}))
+	if err != nil {
+		return nil, err
+	}
+	return &StoreTheIndexProviderStore{c: c}, nil
+}
+
+type StoreTheIndexProviderStore struct {
+	c storetheindex.Client
+}
+
+func (s *StoreTheIndexProviderStore) AddProvider(ctx context.Context, key []byte, prov peer.AddrInfo) error {
+	return fmt.Errorf("adding providers not supported")
+}
+
+func (s *StoreTheIndexProviderStore) GetProviders(ctx context.Context, key []byte) ([]peer.AddrInfo, error) {
+	h, err := multihash.Cast(key)
+	if err != nil {
+		return nil, err
+	}
+	t0 := time.Now()
+	infos, err := s.c.FindProviders(ctx, h)
+	dur := time.Now().Sub(t0)
+	recordSTIFindProvsComplete(ctx, statusFromErr(err), metrics.STIFindProvsDuration.M(float64(dur)))
+	return infos, err
+}
+
+func recordSTIFindProvsComplete(ctx context.Context, status string, extraMeasures ...stats.Measurement) {
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{tag.Upsert(metrics.KeyStatus, status)},
+		append([]stats.Measurement{metrics.STIFindProvs.M(1)}, extraMeasures...)...,
+	)
+}

--- a/providers/storetheindex/client.go
+++ b/providers/storetheindex/client.go
@@ -1,0 +1,42 @@
+package storetheindex
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multihash"
+)
+
+type Client interface {
+	FindProviders(ctx context.Context, mh multihash.Multihash) ([]peer.AddrInfo, error)
+}
+
+type Option func(*client) error
+
+type client struct {
+	client   *http.Client
+	endpoint *url.URL
+}
+
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *client) error {
+		c.client = hc
+		return nil
+	}
+}
+
+func New(endpoint string, opts ...Option) (*client, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	c := &client{endpoint: u, client: http.DefaultClient}
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}

--- a/providers/storetheindex/findproviders.go
+++ b/providers/storetheindex/findproviders.go
@@ -1,0 +1,72 @@
+package storetheindex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multihash"
+)
+
+var logger = logging.Logger("delegated/client")
+
+func (c *client) FindProviders(ctx context.Context, mh multihash.Multihash) ([]peer.AddrInfo, error) {
+	// encode request in URL
+	u := fmt.Sprint(c.endpoint.String(), "/", mh.B58String())
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return []peer.AddrInfo{}, nil
+		}
+		return nil, fmt.Errorf("find query failed: %v", http.StatusText(resp.StatusCode))
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedResponse := indexFindResponse{}
+	if err := json.Unmarshal(body, &parsedResponse); err != nil {
+		return nil, err
+	}
+
+	if len(parsedResponse.MultihashResults) != 1 {
+		return nil, fmt.Errorf("unexpected number of responses")
+	}
+	result := make([]peer.AddrInfo, len(parsedResponse.MultihashResults[0].ProviderResults))
+	for _, m := range parsedResponse.MultihashResults[0].ProviderResults {
+		result = append(result, m.Provider)
+	}
+
+	return result, nil
+}
+
+type indexFindResponse struct {
+	MultihashResults []indexMultihashResult
+}
+
+type indexMultihashResult struct {
+	Multihash       multihash.Multihash
+	ProviderResults []indexProviderResult
+}
+
+type indexProviderResult struct {
+	ContextID []byte
+	Metadata  json.RawMessage
+	Provider  peer.AddrInfo
+}


### PR DESCRIPTION
This looks a lot like the current delegated provider, but makes the request with the json / url format spoken by the current storetheindex find http server.

This PR does connect up metrics to views so that stats on these delegated providers will become visible to prometheus.