### PR TITLE
Use less buckets for some latency metrics

### DIFF
--- a/metrics/definitions.go
+++ b/metrics/definitions.go
@@ -10,7 +10,9 @@ import (
 var (
 	defaultBytesDistribution        = view.Distribution(1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
 	defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
-	defaultProvidersDistribution    = view.Distribution(0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000)
+	// a coarser-grained milliseconds distribution for metrics with higher cardinality and where we don't need a more fine-grained distribution
+	coarseMillisecondsDistribution = view.Distribution(0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000)
+	defaultProvidersDistribution   = view.Distribution(0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000)
 )
 
 // Keys
@@ -106,7 +108,7 @@ var (
 	PrefetchDurationMillisView = &view.View{
 		Measure:     PrefetchDuration,
 		TagKeys:     []tag.Key{KeyName, KeyStatus},
-		Aggregation: defaultMillisecondsDistribution,
+		Aggregation: coarseMillisecondsDistribution,
 	}
 	PrefetchNegativeCacheHitsView = &view.View{
 		Measure:     PrefetchNegativeCacheHits,
@@ -145,7 +147,7 @@ var (
 	AWSRequestsDurationView = &view.View{
 		Measure:     AWSRequestDurationMillis,
 		TagKeys:     []tag.Key{KeyName, KeyOperation, KeyHTTPCode},
-		Aggregation: defaultMillisecondsDistribution,
+		Aggregation: coarseMillisecondsDistribution,
 	}
 	AWSRequestRetriesView = &view.View{
 		Measure:     AWSRequestRetries,
@@ -181,7 +183,7 @@ var (
 	OutboundRequestLatencyView = &view.View{
 		Measure:     dhtmetrics.OutboundRequestLatency,
 		TagKeys:     []tag.Key{dhtmetrics.KeyMessageType},
-		Aggregation: defaultMillisecondsDistribution,
+		Aggregation: coarseMillisecondsDistribution,
 	}
 	SentMessagesView = &view.View{
 		Measure:     dhtmetrics.SentMessages,


### PR DESCRIPTION
The motivation is that we are getting some errors from Prometheus
because of the cardinality created by the large # buckets.

For many latency metrics we just need ballpark figures, we don't need
fine-grained numbers.