### PR TITLE
Filter bitswap records for hydras

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multicodec v0.4.0
 	github.com/multiformats/go-multihash v0.0.15
+	github.com/multiformats/go-varint v0.0.6
 	github.com/ncabatoff/process-exporter v0.7.10
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/node_exporter v1.3.1

--- a/providers/storetheindex/mockserver.go
+++ b/providers/storetheindex/mockserver.go
@@ -36,7 +36,10 @@ func (m *mockServer) ServeHTTP(writer http.ResponseWriter, request *http.Request
 
 	provResults := []indexProviderResult{}
 	for _, ai := range ais {
-		provResults = append(provResults, indexProviderResult{Provider: ai})
+		provResults = append(provResults, indexProviderResult{
+			Metadata: bitswapPrefix,
+			Provider: ai,
+		})
 	}
 
 	resp := indexFindResponse{


### PR DESCRIPTION
Currently, all provider records coming back from storetheindex are being returned to clients.
We should filter that implicitly to only providers advertising bitswap while clients are implicitly expecting that behavior.