### PR TITLE
fix: remove wildcard from Docker build push event

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,7 @@
 name: Publish Docker image
 
 on:
-  push:
-    branches:
-      - '*'
+  push
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
For some reason the asterisk wildcard has stopped working, but removing the condition entirely works.

This is from the docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push