### PR TITLE
feat: add peer store export http endpoint

### DIFF
--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -3,7 +3,9 @@ package httpapi
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -145,6 +147,7 @@ func pstoreListHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request)
 				// get all protocols
 				protocols, err := ps.GetProtocols(p)
 				if err != nil {
+					fmt.Printf("error getting protocols: %s\n", err)
 					protocols = []string{}
 				}
 
@@ -155,12 +158,19 @@ func pstoreListHandler(hy *hydra.Hydra) func(http.ResponseWriter, *http.Request)
 				}
 
 				// marshal and send response to client
-				enc.Encode(PeerInfo{
+				err = enc.Encode(PeerInfo{
 					AddrInfo:     pi,
 					HeadID:       head.Host.ID(),
 					AgentVersion: agentVersion,
 					Protocols:    protocols,
 				})
+				if err != nil {
+					fmt.Printf("error encoding peer info: %s\n", err)
+					var netErr net.Error
+					if errors.As(err, &netErr) {
+						return
+					}
+				}
 			}
 		}
 	}

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -244,7 +244,7 @@ func TestHTTPAPIRecordsFetchErrorStates(t *testing.T) {
 }
 
 func TestHTTPAPIPStoreList(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(hydratesting.NewContext())
 	defer cancel()
 
 	hds, err := head.SpawnTestHeads(ctx, 1)

--- a/httpapi/httpapi_test.go
+++ b/httpapi/httpapi_test.go
@@ -243,6 +243,48 @@ func TestHTTPAPIRecordsFetchErrorStates(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIPStoreList(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hds, err := head.SpawnTestHeads(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go http.Serve(listener, NewRouter(&hydra.Hydra{Heads: hds, SharedDatastore: hds[0].Datastore}))
+	defer listener.Close()
+
+	url := fmt.Sprintf("http://%s/pstore/list", listener.Addr().String())
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		t.Fatal(fmt.Errorf("got non-2XX status code %d: %s", res.StatusCode, url))
+	}
+
+	dec := json.NewDecoder(res.Body)
+
+	var peerInfos []PeerInfo
+	for {
+		var pi PeerInfo
+		if err := dec.Decode(&pi); err != nil {
+			break
+		}
+		peerInfos = append(peerInfos, pi)
+	}
+
+	if len(peerInfos) == 0 {
+		t.Fatalf("Expected to have more than 0 peer records stored, found %d", len(peerInfos))
+	}
+}
+
 func TestIDGeneratorAdd(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {


### PR DESCRIPTION
We want to correlate provider records with their corresponding peer records to get a sense of content replication and content locality (inferred from multi addresses).

Hydras are currently running with an in-memory peerstores (one for each head) and there's (afaik) no way to access/dump them.

An alternative that we considered was to switch from an in-memory peerstore to a LevelDB-backed one and export data from there. However, only a single process (possibly multi-threaded) can access a particular LevelDB database at a time. This means we're back at square one.

This PR adds an endpoint that loops through all hydra+heads plus all peers in their peerstores and serves their information (PeerID, multiaddresses, agent version, supported protocols) to the requesting client.
