### PR TITLE
Allow discarding writes with reframe

### DIFF
--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -269,6 +269,11 @@ func NewHydra(ctx context.Context, options Options) (*Hydra, error) {
 }
 
 func newProviderStoreBuilder(ctx context.Context, options Options) (opts.ProviderStoreBuilderFunc, error) {
+	if options.ProviderStore == "none" {
+		return func(opts opts.Options, host host.Host) (providers.ProviderStore, error) {
+			return &hproviders.NoopProviderStore{}, nil
+		}, nil
+	}
 	if strings.HasPrefix(options.ProviderStore, "dynamodb://") {
 		// dynamodb,table=<table>,ttl=<ttl>,queryLimit=<queryLimit>
 		ddbOpts, err := utils.ParseOptsString(strings.TrimPrefix(options.ProviderStore, "dynamodb://"))

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	idOffset := flag.Int("id-offset", -1, "What offset in the sequence of keys generated from random-seed to start from")
 	dbpath := flag.String("db", "", "Datastore directory (for LevelDB store) or postgresql:// connection URI (for PostgreSQL store) or 'dynamodb://table=<string>'")
 	pstorePath := flag.String("pstore", "", "Peerstore directory for LevelDB store (defaults to in-memory store)")
-	providerStore := flag.String("provider-store", "", "A non-default provider store to use, \"dynamodb://table=<string>,ttl=<ttl-in-seconds>,queryLimit=<int>\"")
+	providerStore := flag.String("provider-store", "", "A non-default provider store to use, either \"none\" or \"dynamodb://table=<string>,ttl=<ttl-in-seconds>,queryLimit=<int>\"")
 	httpAPIAddr := flag.String("httpapi-addr", defaultHTTPAPIAddr, "Specify an IP and port to run the HTTP API server on")
 	delegateTimeout := flag.Int("delegate-timeout", 0, "Timeout for delegated routing in milliseconds")
 	reframeAddr := flag.String("reframe-addr", "", "Reframe API endpoint for delegated routing")

--- a/providers/noop.go
+++ b/providers/noop.go
@@ -1,0 +1,17 @@
+package providers
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type NoopProviderStore struct{}
+
+func (s *NoopProviderStore) AddProvider(ctx context.Context, key []byte, prov peer.AddrInfo) error {
+	return nil
+}
+
+func (s *NoopProviderStore) GetProviders(ctx context.Context, key []byte) ([]peer.AddrInfo, error) {
+	return nil, nil
+}

--- a/providers/reframe.go
+++ b/providers/reframe.go
@@ -36,7 +36,9 @@ type reframeProvider struct {
 }
 
 func (x *reframeProvider) AddProvider(ctx context.Context, key []byte, prov peer.AddrInfo) error {
-	return fmt.Errorf("reframe does not support adding providers")
+	// This swallows adds so that this can be plugged in directly to the DHT implementation,
+	// which calls this method on incoming puts. In that case we just swallow the put and do nothing.
+	return nil
 }
 
 func emptyIndicator(x int64) int64 {
@@ -63,7 +65,6 @@ func (x *reframeProvider) GetProviders(ctx context.Context, key []byte) ([]peer.
 		numPeers := int64(len(peers))
 		stats.Record(ctx, metrics.STIFindProvsLength.M(numPeers))
 		stats.Record(ctx, metrics.STIFindProvsEmpty.M(emptyIndicator(numPeers)))
-		fmt.Printf("numPeers: %d\n", numPeers)
 	}
 	return peers, err
 }


### PR DESCRIPTION
This will allow the hydras to run in a mode where they look like DHT nodes, and accept writes, but silently discard the writes and always return only results from indexers.