### PR TITLE
Allow configuring connection manager's limits

### DIFF
--- a/head/head.go
+++ b/head/head.go
@@ -108,7 +108,7 @@ func NewHead(ctx context.Context, options ...opts.Option) (*Head, chan Bootstrap
 	cfg := opts.Options{}
 	cfg.Apply(append([]opts.Option{opts.Defaults}, options...)...)
 
-	cmgr, err := connmgr.NewConnManager(cfg.ConnMgrLowWater, cfg.ConnMgrHighWater, connmgr.WithGracePeriod(time.Duration(cfg.ConnMgrGracePeriod)*time.Millisecond))
+	cmgr, err := connmgr.NewConnManager(cfg.ConnMgrLowWater, cfg.ConnMgrHighWater, connmgr.WithGracePeriod(cfg.ConnMgrGracePeriod))
 	if err != nil {
 		return nil, nil, fmt.Errorf("building connmgr: %w", err)
 	}

--- a/head/head.go
+++ b/head/head.go
@@ -39,9 +39,6 @@ import (
 
 const (
 	providerRecordsTaskInterval = time.Minute * 5
-	lowWater                    = 1200
-	highWater                   = 1800
-	gracePeriod                 = time.Minute
 	provDisabledGCInterval      = time.Hour * 24 * 365 * 100 // set really high to be "disabled"
 	provCacheSize               = 256
 	provCacheExpiry             = time.Hour
@@ -111,9 +108,9 @@ func NewHead(ctx context.Context, options ...opts.Option) (*Head, chan Bootstrap
 	cfg := opts.Options{}
 	cfg.Apply(append([]opts.Option{opts.Defaults}, options...)...)
 
-	cmgr, err := connmgr.NewConnManager(lowWater, highWater, connmgr.WithGracePeriod(gracePeriod))
+	cmgr, err := connmgr.NewConnManager(cfg.ConnMgrLowWater, cfg.ConnMgrHighWater, connmgr.WithGracePeriod(time.Duration(cfg.ConnMgrGracePeriod)*time.Millisecond))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("building connmgr: %w", err)
 	}
 
 	ua := version.UserAgent

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	ResourceManagerLimitsFile string
 	ConnMgrHighWater          int
 	ConnMgrLowWater           int
-	ConnMgrGracePeriod        int
+	ConnMgrGracePeriod        time.Duration
 }
 
 // Option is the Hydra Head option type.
@@ -70,7 +70,7 @@ var Defaults = func(o *Options) error {
 	o.BootstrapPeers = dht.DefaultBootstrapPeers
 	o.ConnMgrHighWater = 1800
 	o.ConnMgrLowWater = 1200
-	o.ConnMgrGracePeriod = 60000
+	o.ConnMgrGracePeriod = time.Minute
 	return nil
 }
 

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -3,6 +3,7 @@ package opts
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -40,6 +40,9 @@ type Options struct {
 	ProvidersFinder           hproviders.ProvidersFinder
 	DisableResourceManager    bool
 	ResourceManagerLimitsFile string
+	ConnMgrHighWater          int
+	ConnMgrLowWater           int
+	ConnMgrGracePeriod        int
 }
 
 // Option is the Hydra Head option type.
@@ -65,6 +68,9 @@ var Defaults = func(o *Options) error {
 	o.ProtocolPrefix = dht.DefaultPrefix
 	o.BucketSize = 20
 	o.BootstrapPeers = dht.DefaultBootstrapPeers
+	o.ConnMgrHighWater = 1800
+	o.ConnMgrLowWater = 1200
+	o.ConnMgrGracePeriod = 60000
 	return nil
 }
 
@@ -231,6 +237,27 @@ func DisableResourceManager(b bool) Option {
 func ResourceManagerLimitsFile(f string) Option {
 	return func(o *Options) error {
 		o.ResourceManagerLimitsFile = f
+		return nil
+	}
+}
+
+func ConnMgrHighWater(n int) Option {
+	return func(o *Options) error {
+		o.ConnMgrHighWater = n
+		return nil
+	}
+}
+
+func ConnMgrLowWater(n int) Option {
+	return func(o *Options) error {
+		o.ConnMgrLowWater = n
+		return nil
+	}
+}
+
+func ConnMgrGracePeriod(n int) Option {
+	return func(o *Options) error {
+		o.ConnMgrGracePeriod = n
 		return nil
 	}
 }

--- a/head/opts/options.go
+++ b/head/opts/options.go
@@ -255,7 +255,7 @@ func ConnMgrLowWater(n int) Option {
 	}
 }
 
-func ConnMgrGracePeriod(n int) Option {
+func ConnMgrGracePeriod(n time.Duration) Option {
 	return func(o *Options) error {
 		o.ConnMgrGracePeriod = n
 		return nil

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -85,7 +85,7 @@ type Options struct {
 	ResourceManagerLimitsFile string
 	ConnMgrHighWater          int
 	ConnMgrLowWater           int
-	ConnMgrGracePeriod        int
+	ConnMgrGracePeriod        time.Duration
 }
 
 // NewHydra creates a new Hydra with the passed options.

--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -83,6 +83,9 @@ type Options struct {
 	DisableDBCreate           bool
 	DisableResourceManager    bool
 	ResourceManagerLimitsFile string
+	ConnMgrHighWater          int
+	ConnMgrLowWater           int
+	ConnMgrGracePeriod        int
 }
 
 // NewHydra creates a new Hydra with the passed options.
@@ -181,6 +184,9 @@ func NewHydra(ctx context.Context, options Options) (*Hydra, error) {
 			opts.DelegateHTTPClient(delegateHTTPClient),
 			opts.DisableResourceManager(options.DisableResourceManager),
 			opts.ResourceManagerLimitsFile(options.ResourceManagerLimitsFile),
+			opts.ConnMgrHighWater(options.ConnMgrHighWater),
+			opts.ConnMgrLowWater(options.ConnMgrLowWater),
+			opts.ConnMgrGracePeriod(options.ConnMgrGracePeriod),
 		}
 		if options.EnableRelay {
 			hdOpts = append(hdOpts, opts.EnableRelay())

--- a/main.go
+++ b/main.go
@@ -140,7 +140,10 @@ func main() {
 	}
 
 	if *connMgrGracePeriod == defaultConnMgrGracePeriod {
-		*connMgrGracePeriod = os.Getenv("HYDRA_CONNMGR_GRACE_PERIOD", defaultConnMgrGracePeriod)
+		envVal := os.Getenv("HYDRA_CONNMGR_GRACE_PERIOD")
+		if envVal != "" {
+			*connMgrGracePeriod = envVal
+		}
 	}
 	connMgrGracePeriodDuration, err := time.ParseDuration(*connMgrGracePeriod)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ const (
 	defaultHTTPAPIAddr        = "127.0.0.1:7779"
 	defaultConnMgrHighWater   = 1800
 	defaultConnMgrLowWater    = 1200
-	defaultConnMgrGracePeriod = 60000
+	defaultConnMgrGracePeriod = "60s"
 )
 
 func main() {
@@ -208,7 +208,7 @@ func main() {
 
 		ConnMgrHighWater:   *connMgrHighWater,
 		ConnMgrLowWater:    *connMgrLowWater,
-		ConnMgrGracePeriod: *connMgrGracePeriod,
+		ConnMgrGracePeriod: connMgrGracePeriodDuration,
 	}
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	resourceManagerLimits := flag.String("rcmgr-limits", "", "Resource Manager limits JSON config (default none).")
 	connMgrHighWater := flag.Int("connmgr-high-water", defaultConnMgrHighWater, "High water limit for the connection manager.")
 	connMgrLowWater := flag.Int("connmgr-low-water", defaultConnMgrLowWater, "Low water limit for the connection manager.")
-	connMgrGracePeriod := flag.Int("connmgr-low-water", defaultConnMgrGracePeriod, "Grace period for connections (in ms).")
+	connMgrGracePeriod := flag.String("connmgr-grace-period", defaultConnMgrGracePeriod, "Grace period for connections as a Go duration string such as \"60s\".")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -140,7 +140,11 @@ func main() {
 	}
 
 	if *connMgrGracePeriod == defaultConnMgrGracePeriod {
-		*connMgrGracePeriod = mustGetEnvInt("HYDRA_CONNMGR_GRACE_LIMIT", defaultConnMgrGracePeriod)
+		*connMgrGracePeriod = os.Getenv("HYDRA_CONNMGR_GRACE_PERIOD", defaultConnMgrGracePeriod)
+	}
+	connMgrGracePeriodDuration, err := time.ParseDuration(*connMgrGracePeriod)
+	if err != nil {
+		log.Fatalf("parsing grace period duration: %s", err)
 	}
 
 	// Allow short keys. Otherwise, we'll refuse connections from the bootsrappers and break the network.


### PR DESCRIPTION
This exposes the ability to set HighWater, LowWater and GracePeriod for the libp2p connection manager.