### PR TITLE
Pin alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY main.go promconfig.yaml ./
 RUN go install -tags=openssl -v ./...
 
 # Create single-layer run image
-FROM alpine
+FROM alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 RUN apk add --no-cache openssl curl  # curl is for health checking
 COPY --from=build /go/bin/hydra-booster /hydra-booster
 COPY --from=build /go/bin/mock-routing-server /mock-routing-server


### PR DESCRIPTION
The new version has some backwards-incompatible change in OpenSSL causing runtime errors. We should upgrade this later, this is a stopgap.