### PR TITLE
feat: add support for delegated routing HTTP API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-ipns v0.3.0
+	github.com/ipfs/go-libipfs v0.0.0-20221207180439-c7e7738575f9
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/ipfs-ds-postgres v0.2.0
 	github.com/ipld/edelweiss v0.2.0
@@ -167,6 +168,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/safchain/ethtool v0.1.0 // indirect
+	github.com/samber/lo v1.36.0 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect

--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,10 @@ github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2PO
 github.com/ipfs/go-ipfs-util v0.0.2/go.mod h1:CbPtkWJzjLdEcezDns2XYaehFVNXG9zrdrtMecczcsQ=
 github.com/ipfs/go-ipns v0.3.0 h1:ai791nTgVo+zTuq2bLvEGmWP1M0A6kGTXUsgv/Yq67A=
 github.com/ipfs/go-ipns v0.3.0/go.mod h1:3cLT2rbvgPZGkHJoPO1YMJeh6LtkxopCkKFcio/wE24=
+github.com/ipfs/go-libipfs v0.0.0-20221206130039-8dda74356068 h1:f4aUGWf4cqWJuikcwCPk/9GegRXcFMUx3V4soQ8ipT4=
+github.com/ipfs/go-libipfs v0.0.0-20221206130039-8dda74356068/go.mod h1:gAc/IsxQh4HwAOeSCKM1ONfzCQfNbm9E8QqEVfiPfOU=
+github.com/ipfs/go-libipfs v0.0.0-20221207180439-c7e7738575f9 h1:rQkkhUmGyAMy1Pr/cSAmcp/0i+ur+koewOKfTD4UU3A=
+github.com/ipfs/go-libipfs v0.0.0-20221207180439-c7e7738575f9/go.mod h1:blLqyfvHD86wgXMJ8GR4QQWYeg1ZvFHOhX3DT340Nj8=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log v1.0.3/go.mod h1:OsLySYkwIbiSUR/yBTdv1qPtcE4FW3WPWk/ewz9Ru+A=
 github.com/ipfs/go-log v1.0.4/go.mod h1:oDCg2FkjogeFOhqqb+N39l2RpTNPL6F/StPkB3kPgcs=
@@ -922,6 +926,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.1.0 h1:SsRnt87qssm3RltLJze6kM+4fs32twq6mZEcBxbDMVg=
 github.com/safchain/ethtool v0.1.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
+github.com/samber/lo v1.36.0 h1:4LaOxH1mHnbDGhTVE0i1z8v/lWaQW8AIfOD3HU4mSaw=
+github.com/samber/lo v1.36.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -1006,6 +1012,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/providers/httpapi.go
+++ b/providers/httpapi.go
@@ -1,0 +1,58 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/ipfs/go-cid"
+	drc "github.com/ipfs/go-libipfs/routing/http/client"
+	"github.com/ipfs/go-libipfs/routing/http/contentrouter"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
+)
+
+type readContentRouter interface {
+	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.AddrInfo
+}
+
+func NewHTTPProviderStore(httpClient *http.Client, endpointURL string) (*httpProvider, error) {
+	drClient, err := drc.New(endpointURL, drc.WithHTTPClient(httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("building delegated routing HTTP client: %w", err)
+	}
+	cr := contentrouter.NewContentRoutingClient(drClient)
+
+	return &httpProvider{
+		cr: cr,
+	}, nil
+}
+
+type httpProvider struct {
+	cr readContentRouter
+}
+
+func (p *httpProvider) AddProvider(ctx context.Context, key []byte, prov peer.AddrInfo) error {
+	return nil
+}
+
+func (p *httpProvider) GetProviders(ctx context.Context, key []byte) ([]peer.AddrInfo, error) {
+	mh, err := multihash.Cast(key)
+	if err != nil {
+		return nil, err
+	}
+	c := cid.NewCidV1(cid.Raw, mh)
+	provChan := p.cr.FindProvidersAsync(ctx, c, 100)
+	var provs []peer.AddrInfo
+	for {
+		select {
+		case <-ctx.Done():
+			return provs, ctx.Err()
+		case prov, ok := <-provChan:
+			if !ok {
+				return provs, nil
+			}
+			provs = append(provs, prov)
+		}
+	}
+}

--- a/providers/reframe.go
+++ b/providers/reframe.go
@@ -59,9 +59,9 @@ func (x *reframeProvider) GetProviders(ctx context.Context, key []byte) ([]peer.
 
 	if err != nil {
 		log.Errorf("reframe error: %s", err)
-		recordReframeFindProvsComplete(ctx, metricsErrStr(err), time.Since(start))
+		recordSTIFindProvsComplete(ctx, metricsErrStr(err), time.Since(start))
 	} else {
-		recordReframeFindProvsComplete(ctx, "Success", time.Since(start))
+		recordSTIFindProvsComplete(ctx, "Success", time.Since(start))
 		numPeers := int64(len(peers))
 		stats.Record(ctx, metrics.STIFindProvsLength.M(numPeers))
 		stats.Record(ctx, metrics.STIFindProvsEmpty.M(emptyIndicator(numPeers)))
@@ -115,7 +115,7 @@ func metricsErrStr(err error) string {
 	return "Other"
 }
 
-func recordReframeFindProvsComplete(ctx context.Context, status string, duration time.Duration) {
+func recordSTIFindProvsComplete(ctx context.Context, status string, duration time.Duration) {
 	stats.RecordWithTags(
 		ctx,
 		[]tag.Mutator{tag.Upsert(metrics.KeyStatus, status)},


### PR DESCRIPTION
Example metrics output:

Run with: `./hydra -nheads 100 -port-begin 30000 -disable-prefetch -provider-store https://cid.contact -name gus`

```
$ curl -s http://127.0.0.1:9758/metrics | grep routing_http
# HELP hydrabooster_routing_http_client_latency the latency of operations by the routing HTTP client
# TYPE hydrabooster_routing_http_client_latency histogram
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="1"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="2"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="5"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="10"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="20"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="50"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="100"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="200"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="500"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="1000"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="2000"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="5000"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="10000"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="20000"} 0
hydrabooster_routing_http_client_latency_bucket{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders",le="+Inf"} 2
hydrabooster_routing_http_client_latency_sum{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders"} 1.17596292e+08
hydrabooster_routing_http_client_latency_count{code="200",error="None",host="cid.contact",name="gus",operation="FindProviders"} 2
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="1"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="2"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="5"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="10"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="20"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="50"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="100"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="200"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="500"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="1000"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="2000"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="5000"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="10000"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="20000"} 0
hydrabooster_routing_http_client_latency_bucket{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders",le="+Inf"} 6
hydrabooster_routing_http_client_latency_sum{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders"} 6.55570114e+08
hydrabooster_routing_http_client_latency_count{code="404",error="None",host="cid.contact",name="gus",operation="FindProviders"} 6
# HELP hydrabooster_routing_http_client_length the number of elements in a response collection
# TYPE hydrabooster_routing_http_client_length histogram
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="1"} 6
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="2"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="5"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="10"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="11"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="12"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="15"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="20"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="50"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="100"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="200"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="500"} 8
hydrabooster_routing_http_client_length_bucket{host="cid.contact",name="gus",operation="FindProviders",le="+Inf"} 8
hydrabooster_routing_http_client_length_sum{host="cid.contact",name="gus",operation="FindProviders"} 2.0000000000000004
hydrabooster_routing_http_client_length_count{host="cid.contact",name="gus",operation="FindProviders"} 8
```